### PR TITLE
Disable class attributes separation

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -57,7 +57,8 @@ return PhpCsFixer\Config::create()
                 "yield",
             ],
         ],
-        // disabled, as this forces the brace on the same line, if the method arguments are over multiple lines (to be compatible with PSR-2
+        // disabled, as this forces the brace on the same line, if the method arguments are over multiple lines (to be compatible with PSR-2)
+        // see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3637
 //        "braces" => [
 //            "allow_single_line_closure" => true,
 //            "position_after_anonymous_constructs" => "next",

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -67,7 +67,11 @@ return PhpCsFixer\Config::create()
         "cast_spaces" => [
             "space" => "single",
         ],
-        "class_attributes_separation" => true,
+        // Disabled, as we can't configure *2* blank lines to separate
+        // see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4001
+//        "class_attributes_separation" => [
+//            "elements" => ["method", "property"],
+//        ],
         "class_definition" => true,
         "combine_consecutive_issets" => true,
         "combine_consecutive_unsets" => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -58,7 +58,7 @@ return PhpCsFixer\Config::create()
             ],
         ],
         // disabled, as this forces the brace on the same line, if the method arguments are over multiple lines (to be compatible with PSR-2)
-        // see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3637
+        // see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3637#issuecomment-409987422
 //        "braces" => [
 //            "allow_single_line_closure" => true,
 //            "position_after_anonymous_constructs" => "next",


### PR DESCRIPTION
See the linked issues.
As soon as they are resolved, we might think about re-adding them again.