### PR TITLE
Upgrade PhpStan dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": "^7.1",
         "friendsofphp/php-cs-fixer": "^2.12",
-        "phpstan/phpstan": "^0.10.2",
-        "phpstan/phpstan-doctrine": "^0.10.0",
-        "phpstan/phpstan-symfony": "^0.10.0",
+        "phpstan/phpstan": "^0.11.0",
+        "phpstan/phpstan-doctrine": "^0.11.0",
+        "phpstan/phpstan-symfony": "^0.11.0",
         "symfony/phpunit-bridge": "^4.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": "^7.1",
         "friendsofphp/php-cs-fixer": "^2.12",
-        "phpstan/phpstan": "^0.11.0",
-        "phpstan/phpstan-doctrine": "^0.11.0",
-        "phpstan/phpstan-symfony": "^0.11.0",
+        "phpstan/phpstan": "^0.11.1",
+        "phpstan/phpstan-doctrine": "^0.11",
+        "phpstan/phpstan-symfony": "^0.11",
         "symfony/phpunit-bridge": "^4.0"
     },
     "config": {


### PR DESCRIPTION
Since PhpStan is still pre-1.0, we have to manually upgrade the versions in order to receive fixes such as correctly handling private Symfony services.