### PR TITLE
Ignore all errors related to the node definition + node parent interface

### DIFF
--- a/phpstan_lib.neon
+++ b/phpstan_lib.neon
@@ -15,5 +15,5 @@ parameters:
         - %rootDir%/../../../vendor
 
     ignoreErrors:
-        - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)\.#'
-        - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::children\(\)\.#'
+        - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::#'
+        - '#Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::#'


### PR DESCRIPTION
This interface is just too dynamic for phpstan..