### PR TITLE
enable `inferPrivatePropertyTypeFromConstructor` in PhpStan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.0.8
+=====
+
+*   (improvement) enable `inferPrivatePropertyTypeFromConstructor` in PhpStan
+
+
 3.0.7
 =====
 

--- a/phpstan/lib.neon
+++ b/phpstan/lib.neon
@@ -4,6 +4,7 @@ includes:
 parameters:
     level: 5
 
+    inferPrivatePropertyTypeFromConstructor: true
     reportUnmatchedIgnoredErrors: false
 
     excludes_analyse:


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
