### PR TITLE
PHP-CS-Fixer: allow single line PHPDoc comments.

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -204,7 +204,6 @@ return PhpCsFixer\Config::create()
         ],
         "phpdoc_align" => true,
         "phpdoc_indent" => true,
-        "phpdoc_line_span" => true,
         "phpdoc_no_access" => true,
         "phpdoc_no_alias_tag" => true,
         "phpdoc_no_empty_return" => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.0.12
+======
+
+*   (improvement) PHP-CS-Fixer: allow single line PHPDoc comments.
+
+
 3.0.11
 ======
 


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
