### PR TITLE
Allow "obsolete" variables in PHP

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 | Q             | A
 | ------------- | --------------------------------------------------------------------- |
-| Bug fix?      | yes/no                                                                |
+| BC breaks?    | yes/no                                                                |
 | New feature?  | yes/no <!-- don't forget to update CHANGELOG.md -->                   |
 | Improvement?  | yes/no <!-- improves an existing feature, not adding a new one -->    |
-| BC breaks?    | yes/no                                                                |
+| Bug fix?      | yes/no                                                                |
 | Deprecations? | yes/no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
 | Docs PR       | **missing** <!-- insert URL here -->                                  |
 

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -227,7 +227,6 @@ return PhpCsFixer\Config::create()
         "protected_to_private" => true,
         "psr4" => true,
         "random_api_migration" => true,
-        "return_assignment" => true,
         "return_type_declaration" => [
             "space_before" => "one",
         ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.0.13
+======
+
+*   (improvement) Allow "obsolete" variables in PHP (as they are often used for type doc "casting").
+
+
 3.0.12
 ======
 


### PR DESCRIPTION
(as they are often used for type doc "casting")

| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
